### PR TITLE
add element column to peak_report

### DIFF
--- a/efxtools/realspace/find_peaks.py
+++ b/efxtools/realspace/find_peaks.py
@@ -152,6 +152,7 @@ def peak_report(
             "seqid"   :    cra.residue.seqid.num,
             "residue" :    cra.residue.name,
             "atom"    :    cra.atom.name,
+            "element" :    cra.atom.element.name,
             "dist"    :    dist,
             "peakz"   :    (blob.peak_value-mean)/sigma,
             "scorez"  :    (blob.score-mean)/sigma,


### PR DESCRIPTION
I realized it is nice to be able to group peak_reports by element. This is especially important when dealing with anomalous data. Particularly, methionine and cysteine sulfurs don't have the same `atom.name` in `gemmi`. 

I think this should be uncontroversial, but please let me know if I did something stupid here. 