### PR TITLE
Update Hekstra-Lab organization references to rs-station

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # rs-booster
-![Build](https://github.com/Hekstra-Lab/rs-booster/workflows/Build/badge.svg)
+![Build](https://github.com/rs-station/rs-booster/workflows/Build/badge.svg)
 [![PyPI](https://img.shields.io/pypi/v/rs-booster?color=blue)](https://pypi.org/project/rs-booster/)  
 
 `rs-booster` contains commandline scripts for diffraction data analysis tasks.
 
-This package can be viewed as a "booster rocket" for [`reciprocalspaceship`](https://github.com/Hekstra-Lab/reciprocalspaceship).
+This package can be viewed as a "booster rocket" for [`reciprocalspaceship`](https://github.com/rs-station/reciprocalspaceship).
 
 
 ### Installation
@@ -18,7 +18,7 @@ pip install rs-booster
 If you are interested in getting access to new features that haven't yet made it into a release, you can install `rs-booster` from source:
 
 ```bash
-git clone https://github.com/Hekstra-Lab/rs-booster.git
+git clone https://github.com/rs-station/rs-booster.git
 cd rs-booster
 python -m pip install -e .
 ```

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ rs-booster contains commandline scripts for diffraction data analysis tasks.
 This package can be viewed as a "booster pack" for reciprocalspaceship.
 """
 PROJECT_URLS = {
-    "Bug Tracker": "https://github.com/Hekstra-Lab/rs-booster/issues",
-    "Source Code": "https://github.com/Hekstra-Lab/rs-booster",
+    "Bug Tracker": "https://github.com/rs-station/rs-booster/issues",
+    "Source Code": "https://github.com/rs-station/rs-booster",
 }
 
 # Testing requirements
@@ -34,7 +34,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     author="Jack B. Greisman",
     author_email="greisman@g.harvard.edu",
-    url="https://github.com/Hekstra-Lab/rs-booster",
+    url="https://github.com/rs-station/rs-booster",
     project_urls=PROJECT_URLS,
     python_requires=">3.7",
     install_requires=["reciprocalspaceship", "matplotlib", "seaborn"],


### PR DESCRIPTION
This updates all repo references that point to the "Hekstra-Lab" github organization to the "rs-station" org. As a side effect, this will also confirm that the CI works as intended after the repo transfer.