### PR TITLE
pin `seaborn` version to 0.11.2 or less

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,10 @@ setup(
     url="https://github.com/rs-station/rs-booster",
     project_urls=PROJECT_URLS,
     python_requires=">3.7",
-    install_requires=["reciprocalspaceship", "matplotlib", "seaborn"],
+    install_requires=["reciprocalspaceship",
+                      "matplotlib",
+                      "seaborn==0.11.2"
+                      ],
     extras_require={
         "dev": tests_require + docs_require,
         "docs": docs_require

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     python_requires=">3.7",
     install_requires=["reciprocalspaceship",
                       "matplotlib",
-                      "seaborn==0.11.2"
+                      "seaborn<=0.11.2"
                       ],
     extras_require={
         "dev": tests_require + docs_require,


### PR DESCRIPTION
Pinning seaborn version to `0.11.2` because `0.12.0` or greater breaks plotting functionality for reasons currently unknown.

This PR probably should not be merged until we have an actual understanding of what has changed!