### PR TITLE
Remove deprecated sphinx_panels

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ extensions = [
     'sphinx_rtd_theme',
     'nbsphinx',
     "sphinx.ext.linkcode",
-    "sphinx_panels",
     "sphinxcontrib.autoprogram",
     "autodocsumm",
 ]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ docs_require = [
         "sphinx",
         "sphinx_rtd_theme",
         "nbsphinx",
-        "sphinx-panels",
         "sphinxcontrib-autoprogram",
         "autodocsumm",
         ]

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,12 @@ tests_require = ["pytest", "pytest-xdist", "pytest-runner"]
 
 # Requirements for building docs
 docs_require = [
-        "sphinx<4",
+        "sphinx",
         "sphinx_rtd_theme",
         "nbsphinx",
         "sphinx-panels",
         "sphinxcontrib-autoprogram",
         "autodocsumm",
-        "Jinja2<3.1",
         ]
 
 setup(


### PR DESCRIPTION
As per discussion with Jack (and the analogous change in `reciprocalspaceship`), removing the unused and deprecated sphinx_panels extension. This was causing the versioning issue with jinja2.