### PR TITLE
made stats functions consistent with BaseParser

### DIFF
--- a/rsbooster/stats/ccanom.py
+++ b/rsbooster/stats/ccanom.py
@@ -119,7 +119,8 @@ def run_analysis(args):
     if args.show:
         plt.show()
 
+def parse_arguments():
+    return ArgumentParser()
 
 def main():
-    parser = ArgumentParser().parse_args()
-    run_analysis(parser)
+    run_analysis(parse_arguments().parse_args())

--- a/rsbooster/stats/ccanom.py
+++ b/rsbooster/stats/ccanom.py
@@ -8,27 +8,27 @@ import reciprocalspaceship as rs
 import seaborn as sns
 
 
-def parse_arguments():
-    """Parse commandline arguments"""
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter, description=__doc__
-    )
-
-    # Required arguments
-    parser.add_argument(
-        "mtz",
-        nargs="+",
-        help="MTZs containing crossvalidation data from careless",
-    )
-    parser.add_argument(
-        "-m",
-        "--method",
-        default="spearman",
-        choices=["spearman", "pearson"],
-        help=("Method for computing correlation coefficient (spearman or pearson)"),
-    )
-
-    return parser#.parse_args()
+from rsbooster.stats.parser import BaseParser
+class ArgumentParser(BaseParser):
+    def __init__(self):
+        super().__init__(
+            description=__doc__
+        )
+        
+        # Required arguments
+        self.add_argument(
+            "mtz",
+            nargs="+",
+            help="MTZs containing crossvalidation data from careless",
+        )
+    
+        self.add_argument(
+            "-m",
+            "--method",
+            default="spearman",
+            choices=["spearman", "pearson"],
+            help=("Method for computing correlation coefficient (spearman or pearson)"),
+        )
 
 
 def make_halves_ccanom(mtz, bins=10):
@@ -51,8 +51,11 @@ def make_halves_ccanom(mtz, bins=10):
 def analyze_ccanom_mtz(mtzpath, bins=10, return_labels=True, method="spearman"):
     """Compute CCsym from 2-fold cross-validation"""
 
-    mtz = rs.read_mtz(mtzpath)
-
+    if type(mtzpath) is rs.dataset.DataSet:
+        mtz=mtzpath
+    else:
+        mtz = rs.read_mtz(mtzpath)
+        
     # Error handling -- make sure MTZ file is appropriate
     if "half" not in mtz.columns:
         raise ValueError("Please provide MTZs from careless crossvalidation")
@@ -75,11 +78,7 @@ def analyze_ccanom_mtz(mtzpath, bins=10, return_labels=True, method="spearman"):
         return result
 
 
-def main():
-
-    # Parse commandline arguments
-    args = parse_arguments().parse_args()
-
+def run_analysis(args):
     results = []
     labels = None
     for m in args.mtz:
@@ -96,18 +95,31 @@ def main():
     results["CCanom"] = results[("DF1", "DF2")]
     results.drop(columns=[("DF1", "DF2")], inplace=True)
 
-    print(results)
+    for k in ('bin', 'repeat'):
+        results[k] = results[k].to_numpy('int32')
+
+    if args.output is not None:
+        results.to_csv(args.output)
+    else:
+        print(results.to_string())
+
+    # print(results.info())
 
     sns.lineplot(
-        data=results, x="bin", y="CCanom", hue="filename", ci="sd", palette="viridis"
+        data=results, x="bin", y="CCanom", hue="filename", errorbar="sd", palette="viridis"
     )
     plt.xticks(range(10), labels, rotation=45, ha="right", rotation_mode="anchor")
     plt.ylabel(r"$CC_{anom}$ " + f"({args.method})")
     plt.legend(loc="center left", bbox_to_anchor=(1, 0.5))
     plt.grid()
     plt.tight_layout()
-    plt.show()
+    if args.image is not None:
+        plt.savefig(args.image)
+
+    if args.show:
+        plt.show()
 
 
-if __name__ == "__main__":
-    main()
+def main():
+    parser = ArgumentParser().parse_args()
+    run_analysis(parser)

--- a/rsbooster/stats/cchalf.py
+++ b/rsbooster/stats/cchalf.py
@@ -117,6 +117,8 @@ def run_analysis(args):
         plt.show()
 
 
+def parse_arguments():
+    return ArgumentParser()
+
 def main():
-    parser = ArgumentParser().parse_args()
-    run_analysis(parser)
+    run_analysis(parse_arguments().parse_args())

--- a/rsbooster/stats/cchalf.py
+++ b/rsbooster/stats/cchalf.py
@@ -8,28 +8,27 @@ import reciprocalspaceship as rs
 import seaborn as sns
 
 
-def parse_arguments():
-    """Parse commandline arguments"""
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter, description=__doc__
-    )
-
-    # Required arguments
-    parser.add_argument(
-        "mtz",
-        nargs="+",
-        help="MTZs containing crossvalidation data from careless",
-    )
-
-    parser.add_argument(
-        "-m",
-        "--method",
-        default="spearman",
-        choices=["spearman", "pearson"],
-        help=("Method for computing correlation coefficient (spearman or pearson)"),
-    )
-
-    return parser#.parse_args()
+from rsbooster.stats.parser import BaseParser
+class ArgumentParser(BaseParser):
+    def __init__(self):
+        super().__init__(
+            description=__doc__
+        )
+        
+        # Required arguments
+        self.add_argument(
+            "mtz",
+            nargs="+",
+            help="MTZs containing crossvalidation data from careless",
+        )
+    
+        self.add_argument(
+            "-m",
+            "--method",
+            default="spearman",
+            choices=["spearman", "pearson"],
+            help=("Method for computing correlation coefficient (spearman or pearson)"),
+        )
 
 
 def make_halves_cchalf(mtz, bins=10):
@@ -54,8 +53,11 @@ def make_halves_cchalf(mtz, bins=10):
 def analyze_cchalf_mtz(mtzpath, bins=10, return_labels=True, method="spearman"):
     """Compute CChalf from 2-fold cross-validation"""
 
-    mtz = rs.read_mtz(mtzpath)
-
+    if type(mtzpath) is rs.dataset.DataSet:
+        mtz=mtzpath
+    else:
+        mtz = rs.read_mtz(mtzpath)
+        
     # Error handling -- make sure MTZ file is appropriate
     if "half" not in mtz.columns:
         raise ValueError("Please provide MTZs from careless crossvalidation")
@@ -73,11 +75,7 @@ def analyze_cchalf_mtz(mtzpath, bins=10, return_labels=True, method="spearman"):
         return result
 
 
-def main():
-
-    # Parse commandline arguments
-    args = parse_arguments().parse_args()
-
+def run_analysis(args):
     results = []
     labels = None
     for m in args.mtz:
@@ -94,18 +92,31 @@ def main():
     results["CChalf"] = results[("F1", "F2")]
     results.drop(columns=[("F1", "F2")], inplace=True)
 
-    print(results)
+    for k in ('bin', 'repeat'):
+        results[k] = results[k].to_numpy('int32')
+
+    if args.output is not None:
+        results.to_csv(args.output)
+    else:
+        print(results.to_string())
+
+    print(results.info())
 
     sns.lineplot(
-        data=results, x="bin", y="CChalf", hue="filename", ci="sd", palette="viridis"
+        data=results, x="bin", y="CChalf", hue="filename", errorbar="sd", palette="viridis"
     )
     plt.xticks(range(10), labels, rotation=45, ha="right", rotation_mode="anchor")
     plt.ylabel(r"$CC_{1/2}$ " + f"({args.method})")
     plt.legend(loc="center left", bbox_to_anchor=(1, 0.5))
     plt.grid()
     plt.tight_layout()
-    plt.show()
+    if args.image is not None:
+        plt.savefig(args.image)
+
+    if args.show:
+        plt.show()
 
 
-if __name__ == "__main__":
-    main()
+def main():
+    parser = ArgumentParser().parse_args()
+    run_analysis(parser)

--- a/rsbooster/stats/ccpred.py
+++ b/rsbooster/stats/ccpred.py
@@ -152,7 +152,8 @@ def run_analysis(args):
     if args.show:
         plt.show()
 
+def parse_arguments():
+    return ArgumentParser()
 
 def main():
-    parser = ArgumentParser().parse_args()
-    run_analysis(parser)
+    run_analysis(parse_arguments().parse_args())

--- a/rsbooster/stats/ccsym.py
+++ b/rsbooster/stats/ccsym.py
@@ -167,6 +167,8 @@ def run_analysis(args):
         plt.show()
 
 
+def parse_arguments():
+    return ArgumentParser()
+
 def main():
-    parser = ArgumentParser().parse_args()
-    run_analysis(parser)
+    run_analysis(parse_arguments().parse_args())

--- a/rsbooster/stats/parser.py
+++ b/rsbooster/stats/parser.py
@@ -1,0 +1,48 @@
+"""
+Base parser for stats functions.
+
+"""
+import argparse
+import numpy as np
+import reciprocalspaceship as rs
+import gemmi
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+class BaseParser(argparse.ArgumentParser):
+    def __init__(self, **kwargs):
+        super().__init__(
+            formatter_class=argparse.RawTextHelpFormatter, 
+            **kwargs
+        )
+
+        self.add_argument(
+            "-s",
+            "--show",
+            action="store_true",
+            help="Make a plot of the results and display it using matplotlib.",
+        )
+
+        self.add_argument(
+            "-i",
+            "--image",
+            type=str,
+            default=None,
+            help="Make a plot of the results and save it to this filename. "
+                 "The filetype will be determined from the filename. "
+                 "Any filetype supported by your matplotlib version will be available.",
+        )
+
+        self.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            default=None,
+            help="Optionally save results to this file in csv format instead of printing "
+                 "them to the terminal.",
+        )
+
+
+


### PR DESCRIPTION
In this PR, 

1. Made all four rs.cc functions compatible with the BaseParser (see also https://github.com/rs-station/careless/blob/main/careless/stats/parser.py), itself taken from careless.stats without modification. This provides the user with a uniform interface and makes it easier to integrate the functions in code that just saves the results as CSV files and figure files by virtue of the `-i`, `-o`, and '-s` flags introduced by the BaseParser. I did not modify any calculations.

2. Changed datatypes from MTZInt to int32 in the `results` DataFrame as introduced by Kevin in the careless.stats functions. This locally addresses the issue https://github.com/rs-station/rs-booster/issues/36

3. In sns.lineplot calls I replaced the `ci` keyword with `errorbar`

4. Made the analyze_...() functions compatible with both MTZ path and rs.DataSet input to facilitate use as function calls within notebooks. I do so using the following:

```
    if type(mtzpath) is rs.dataset.DataSet:
        mtz=mtzpath
    else:
        mtz = rs.read_mtz(mtzpath)
```
5. I have tested each function on Careless output.