### PR TITLE
fix when no peaks above threshold

### DIFF
--- a/rsbooster/realspace/find_peaks.py
+++ b/rsbooster/realspace/find_peaks.py
@@ -171,7 +171,7 @@ def peak_report(
                 record[k] = -record[k]
         peaks.append(record)
 
-    out = pd.DataFrame.from_records(peaks)
+    out = pd.DataFrame.from_records(peaks, columns=long_names.keys())
 
     #In case there are no peaks we need to test the length
     if len(out) > 0:


### PR DESCRIPTION
`rs.find_peaks` and `rs.find_difference_peaks` used to throw and error when no peaks were above the z-score threshold. this fixes this behavior so they simply print an empty csv file with a consistent header. 