### PR TITLE
allow nonstandard settings for space groups

### DIFF
--- a/rsbooster/utils/rfree.py
+++ b/rsbooster/utils/rfree.py
@@ -53,7 +53,7 @@ def parse_arguments():
         "-sg",
         "--spacegroup",
         required=True,
-        type=int,
+        type=str,
         help=("Spacegroup for output mtz file containing rfree flags"),
     )
 


### PR DESCRIPTION
`rs.rfree` restricted the `-sg` / `--spacegroup` argument to be an integer. This is not necessary. `gemmi` will interpret `"19"` and `19` both as meaning P 21 21 21. Allowing string inputs allows the user to specify nonstandard settings such as `P 21 1 1` for spacegroup 4. 