### PR TITLE
Add --ignore-isomorphism flag to rs.scaleit

### DIFF
--- a/rsbooster/scaleit/scaleit.py
+++ b/rsbooster/scaleit/scaleit.py
@@ -49,7 +49,7 @@ def parse_arguments():
     
     parser.add_argument(
         "--ignore-isomorphism",
-        action="store_false",
+        action="store_true",
         help=(
             "Allow poorly isomorphous inputs to be scaled. "
             "By default (no flag) poorly isomorphous inputs will raise an error.")
@@ -148,7 +148,7 @@ def main():
     print(f"Number of common reflections: {len(common)}")
     mtzs = [mtz.loc[common] for mtz in mtzs]
     
-    joined = rs.concat([ref.loc[common]] + mtzs, axis=1, check_isomorphous=args.ignore_isomorphism)
+    joined = rs.concat([ref.loc[common]] + mtzs, axis=1, check_isomorphous=(not args.ignore_isomorphism))
 
     # Run scaleit
     run_scaleit(joined, args.outfile, len(mtzs))

--- a/rsbooster/scaleit/scaleit.py
+++ b/rsbooster/scaleit/scaleit.py
@@ -46,6 +46,14 @@ def parse_arguments():
         default="scaled.mtz",
         help="MTZ file to which scaleit output will be written",
     )
+    
+    parser.add_argument(
+        "--ignore-isomorphism",
+        action="store_false",
+        help=(
+            "Allow poorly isomorphous inputs to be scaled. "
+            "By default (no flag) poorly isomorphous inputs will raise an error.")
+    )
 
     return parser#.parse_args()
 
@@ -139,7 +147,8 @@ def main():
 
     print(f"Number of common reflections: {len(common)}")
     mtzs = [mtz.loc[common] for mtz in mtzs]
-    joined = rs.concat([ref.loc[common]] + mtzs, axis=1)
+    
+    joined = rs.concat([ref.loc[common]] + mtzs, axis=1, check_isomorphous=args.ignore_isomorphism)
 
     # Run scaleit
     run_scaleit(joined, args.outfile, len(mtzs))


### PR DESCRIPTION
As discussed here: https://github.com/rs-station/rs-booster/issues/46 and here: https://github.com/rs-station/matchmaps/issues/43 this PR adds the flag `--ignore-isomorphism` to the `rs.scaleit` utility.

The flag has Boolean behavior, such that when the flag is omitted (default), isomorphism is required; when the flag is included (with no argument) isomorphism is not required.