### PR TITLE
consistent asu diffmap

### DIFF
--- a/rsbooster/diffmaps/diffmap.py
+++ b/rsbooster/diffmaps/diffmap.py
@@ -91,6 +91,10 @@ def main():
             f"{args.Phi} is not a phases column in {args.mtz2}. Try again."
         )
 
+    onmtz=onmtz.hkl_to_asu()
+    offmtz=offmtz.hkl_to_asu()
+    ref=ref.hkl_to_asu()
+    
     diff = onmtz.merge(offmtz, on=["H", "K", "L"], suffixes=("_on", "_off"))
     diff["DF"] = diff["F_on"] - diff["F_off"]
     diff["SigDF"] = np.sqrt((diff["SigF_on"] ** 2) + (diff["SigF_off"] ** 2))

--- a/rsbooster/diffmaps/diffmap.py
+++ b/rsbooster/diffmaps/diffmap.py
@@ -70,7 +70,17 @@ def parse_arguments():
 
     return parser#.parse_args()
 
-
+def remove_HKL_duplicates(ds, ds_name):
+    num_duplicates = np.sum(ds.index.duplicated())
+    if num_duplicates > 0:
+        print(f"Warning: {ds_name} contains {num_duplicates} sets of duplicate Miller indices.")
+        print( "Only the first instance of each HKL will be retained.")
+        # useful diagnostic:
+        # print(ds.reset_index().loc[ds.index.duplicated(keep=False),:].sort_values(["H","K","L"]).head(6))
+        ds=ds.loc[~ds.index.duplicated(keep='first'),:]
+    ds.merged=True
+    return ds
+    
 def main():
 
     # Parse commandline arguments
@@ -94,7 +104,11 @@ def main():
     onmtz=onmtz.hkl_to_asu()
     offmtz=offmtz.hkl_to_asu()
     ref=ref.hkl_to_asu()
-    
+
+    onmtz = remove_HKL_duplicates(onmtz,  'ON MTZ')
+    offmtz= remove_HKL_duplicates(offmtz, 'OFF MTZ')
+    ref   = remove_HKL_duplicates(ref,    'REF MTZ')
+
     diff = onmtz.merge(offmtz, on=["H", "K", "L"], suffixes=("_on", "_off"))
     diff["DF"] = diff["F_on"] - diff["F_off"]
     diff["SigDF"] = np.sqrt((diff["SigF_on"] ** 2) + (diff["SigF_off"] ** 2))
@@ -112,6 +126,7 @@ def main():
     # Useful for PyMOL
     diff["wDF"] = (diff["DF"] * diff["W"]).astype("SFAmplitude")
 
+    
     if args.dmax is None:
         diff.write_mtz(args.outfile)
     else:

--- a/rsbooster/diffmaps/internaldiffmap.py
+++ b/rsbooster/diffmaps/internaldiffmap.py
@@ -84,6 +84,16 @@ def parse_arguments():
 
     return parser#.parse_args()
 
+def remove_HKL_duplicates(ds, ds_name):
+    num_duplicates = np.sum(ds.index.duplicated())
+    if num_duplicates > 0:
+        print(f"Warning: {ds_name} contains {num_duplicates} sets of duplicate Miller indices.")
+        print( "Only the first instance of each HKL will be retained.")
+        # useful diagnostic:
+        # print(ds.reset_index().loc[ds.index.duplicated(keep=False),:].sort_values(["H","K","L"]).head(6))
+        ds=ds.loc[~ds.index.duplicated(keep='first'),:]
+    ds.merged=True
+    return ds
 
 def main():
 
@@ -96,9 +106,11 @@ def main():
         *args.inputmtz, {args.inputmtz[1]: "F", args.inputmtz[2]: "SigF"}
     )
     mtz = mtz.hkl_to_asu()
+    mtz = remove_HKL_duplicates(mtz, 'MTZ of Interest')
     
     ref = rs.read_mtz(refmtz)
     ref = ref.hkl_to_asu()
+    ref = remove_HKL_duplicates(ref, 'REF MTZ')
 
     # Canonicalize column names
     ref.rename(columns={phi_col: "Phi"}, inplace=True)

--- a/rsbooster/utils/io.py
+++ b/rsbooster/utils/io.py
@@ -39,6 +39,7 @@ def subset_to_FSigF(mtzpath, data_col, sig_col, column_names_dict={}):
 
     # Run French-Wilson if intensities are provided
     if isinstance(mtz[data_col].dtype, rs.IntensityDtype):
+        print(f"Applying French-Wilson scaling to columns {data_col} and {sig_col}.")
         scaled = rs.algorithms.scale_merged_intensities(
             mtz, data_col, sig_col, mean_intensity_method="anisotropic"
         )


### PR DESCRIPTION
Summary:
(1) 
For some non-canonical spacegroups (my case going from P21 21 21 to P21 1 1), Phenix and rs appear to not create consistent reciprocal space ASUs. By calling `.hkl_to_asu()` for each input MTZ, this PR ensures that the ASUs _will_ be consistent. This affects both the calculation of ordinary and internal isomorphous difference maps.

(2) for internal difference maps, I include a flag, `-u` or `--union`, which if added leads the script to return a diffmap MTZ file created using the `outer` flag during the `pandas` `merge` call. Columns `wDF`, `DF`, `SigDF` are set to 0 for entries where either contributing reflection is not available. 

(3) I added print statements:
- to specify which symop (as a string) is applied in the internal difference map calculation (since we have been making incorrect assumptions about the numbering of these)
- in utils/io.py to alert the user when `subset_to_F_SigF` applies French-WIlson scaling.

update:
(4) When splitting MTZs by symop and scaling them jointly, Miller indices related to themselves under a relevant symop will be present, in essence, inferred twice. When recombining the output MTZs, one can accidentally include these duplicate entries in the final MTZ (as I did). Although this is an upstream issue, I added a call to a new function (`remove_HKL_duplicates`) to `diffmap.py and `internaldiffmap.py` which checks for the presence of rows with the same Miller indices, removes duplicate entries (except for the first occurrences), and sets merged=True on each MTZ.