### PR TITLE
fix missing import

### DIFF
--- a/rsbooster/__init__.py
+++ b/rsbooster/__init__.py
@@ -1,9 +1,17 @@
-# Version number for rsbooster
+: Version number for reciprocalspaceship
 def getVersionNumber():
-    import pkg_resources
+    version = None
+    try:
+        from setuptools.version import metadata
 
-    version = pkg_resources.require("rs-booster")[0].version
+        version = metadata.version("rs-booster")
+    except ImportError:
+        from setuptools.version import pkg_resources
+
+        version = pkg_resources.require("rs-booster")[0].version
+
     return version
+
 
 
 __version__ = getVersionNumber()

--- a/rsbooster/__init__.py
+++ b/rsbooster/__init__.py
@@ -1,4 +1,4 @@
-: Version number for reciprocalspaceship
+# Version number for rs-booster
 def getVersionNumber():
     version = None
     try:


### PR DESCRIPTION
I'm getting the following error on rs.find_peaks now: 

```python
Traceback (most recent call last):
  File "/global/common/software/lcls/abismal/anaconda/envs/careless/bin/rs.find_peaks", line 3, in <module>
    from rsbooster.realspace.find_peaks import find_peaks
  File "/global/common/software/lcls/abismal/anaconda/envs/careless/lib/python3.12/site-packages/rsbooster/__init__.py", line 9, in <module>
    __version__ = getVersionNumber()
                  ^^^^^^^^^^^^^^^^^^
  File "/global/common/software/lcls/abismal/anaconda/envs/careless/lib/python3.12/site-packages/rsbooster/__init__.py", line 3, in getVersionNumber
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

This is due to pkg_resources being deprecated. We mitigated this already in [rs](https://github.com/rs-station/reciprocalspaceship/pull/273). I am copying the solution to this repo. 